### PR TITLE
Use max_float insteaf of inf 

### DIFF
--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -28,6 +28,7 @@ from json import JSONEncoder
 from stn.pstn.constraint import Constraint
 from stn.stn import STN
 from stn.task import Timepoint
+from stn.stn import MAX_FLOAT
 
 
 class MyEncoder(JSONEncoder):
@@ -71,7 +72,7 @@ class PSTN(STN):
 
         return to_print
 
-    def add_constraint(self, i, j, wji=0.0, wij=float('inf'), distribution=""):
+    def add_constraint(self, i, j, wji=0.0, wij=MAX_FLOAT, distribution=""):
         """
         Adds constraint between nodes i and j
         i: starting node
@@ -86,7 +87,7 @@ class PSTN(STN):
         -wji is the lower bound (minimum allocated time between i and j)
          wij is the upper bound (maximum allocated time between i and j)
 
-        If there is no upper bound, its value is set to infinity
+        If there is no upper bound, its value is set to infinity (MAX_FLOAT)
 
         distribution is the probability distribution of the constraint between i and j
         """
@@ -159,11 +160,11 @@ class PSTN(STN):
     @staticmethod
     def get_prev_timepoint(timepoint_name, next_timepoint, edge_in_between):
         r_earliest_time = 0
-        r_latest_time = float('inf')
+        r_latest_time = MAX_FLOAT
         return Timepoint(timepoint_name, r_earliest_time, r_latest_time)
 
     @staticmethod
     def get_next_timepoint(timepoint_name, prev_timepoint, edge_in_between):
         r_earliest_time = 0
-        r_latest_time = float('inf')
+        r_latest_time = MAX_FLOAT
         return Timepoint(timepoint_name, r_earliest_time, r_latest_time)

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -95,7 +95,7 @@ class STN(nx.DiGraph):
     def is_empty(self):
         return nx.is_empty(self)
 
-    def add_constraint(self, i, j, wji=0.0, wij=float('inf')):
+    def add_constraint(self, i, j, wji=0.0, wij=MAX_FLOAT):
         """
         Adds constraint between nodes i and j
         i: starting node
@@ -110,7 +110,7 @@ class STN(nx.DiGraph):
         -wji is the lower bound (minimum allocated time between i and j)
          wij is the upper bound (maximum allocated time between i and j)
 
-        The default upper and lower bounds are 0 and infinity
+        The default upper and lower bounds are 0 and infinity (MAX_FLOAT)
         """
         # Minimum allocated time between i and j
         min_time = -wji
@@ -387,15 +387,8 @@ class STN(nx.DiGraph):
         :param i: starting_node_id
         :parma ending_node: ending_node_id
         """
-        if weight == "inf":
-            weight = float('inf')
-        else:
-            weight = round(float(weight), 2)
-
         if self.has_edge(i, j):
-
-            if self[i][j]['weight'] == 'inf':
-                self[i][j]['weight'] = float('inf')
+            weight = round(float(weight), 2)
 
             if weight < self[i][j]['weight']:
                 self[i][j]['weight'] = weight
@@ -409,7 +402,7 @@ class STN(nx.DiGraph):
         in node_id
         Args:
             allotted_time (float): seconds after zero timepoint
-            node_id (inf): idx of the timepoint in the stn
+            node_id (int): idx of the timepoint in the stn
 
         """
         self.update_edge_weight(0, node_id, allotted_time, force)
@@ -433,7 +426,7 @@ class STN(nx.DiGraph):
             if i == j and self.has_node(i):
                 return 0
             else:
-                return float('inf')
+                return MAX_FLOAT
 
     def compute_temporal_metric(self, temporal_criterion):
         if temporal_criterion == 'completion_time':

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -2,6 +2,7 @@ from stn.stn import STN
 from json import JSONEncoder
 import logging
 from stn.task import Timepoint
+from stn.stn import MAX_FLOAT
 
 
 class MyEncoder(JSONEncoder):
@@ -45,7 +46,7 @@ class STNU(STN):
 
         return to_print
 
-    def add_constraint(self, i, j, wji=0.0, wij=float('inf'), is_contingent=False):
+    def add_constraint(self, i, j, wji=0.0, wij=MAX_FLOAT, is_contingent=False):
         """
         Adds constraint between nodes i and j
         i: starting node
@@ -60,7 +61,7 @@ class STNU(STN):
         -wji is the lower bound (minimum allocated time between i and j)
          wij is the upper bound (maximum allocated time between i and j)
 
-        If there is no upper bound, its value is set to infinity
+        If there is no upper bound, its value is set to infinity (MAX_FLOAT)
 
         Types of constraints:
         - contingent constraint


### PR DESCRIPTION
- Fix Degree of Strong Controllability
- Json cannot interpret Infinity as a number. When an stn graph was sent to a component written in c++, e.g. the ropod_com_mediator, the Infinity value was mapped to null