### PR TITLE
Rename timepoint names to departure, start, finish

### DIFF
--- a/stn/node.py
+++ b/stn/node.py
@@ -9,7 +9,7 @@ class Node(object):
         if isinstance(task_id, str):
             task_id = from_str(task_id)
         self.task_id = task_id
-        # The node can be of node_type zero_timepoint, start, pickup or delivery
+        # The node can be of node_type zero_timepoint, departure, start or finish
         self.node_type = node_type
         self.is_executed = is_executed
         self.action_id = kwargs.get("action_id")

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -115,9 +115,9 @@ class PSTN(STN):
     def add_intertimepoints_constraints(self, constraints, task):
         """ Adds constraints between the timepoints of a task
         Constraints between:
-        - start and pickup (contingent)
-        - pickup and delivery (contingent)
-        - delivery and next task (if any) (requirement)
+        - departure and start (contingent)
+        - start and finish (contingent)
+        - finish and next task (if any) (requirement)
         Args:
             constraints (list) : list of tuples that defines the pair of nodes between which a new constraint should be added
             Example:
@@ -128,7 +128,7 @@ class PSTN(STN):
         """
         for (i, j) in constraints:
             self.logger.debug("Adding constraint: %s ", (i, j))
-            if self.nodes[i]['data'].node_type == "start":
+            if self.nodes[i]['data'].node_type == "departure":
                 distribution = self.get_travel_time_distribution(task)
                 if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
                     # Make the constraint a requirement constraint
@@ -137,7 +137,7 @@ class PSTN(STN):
                 else:
                     self.add_constraint(i, j, distribution=distribution)
 
-            elif self.nodes[i]['data'].node_type == "pickup":
+            elif self.nodes[i]['data'].node_type == "start":
                 distribution = self.get_work_time_distribution(task)
                 if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
                     # Make the constraint a requirement constraint
@@ -146,8 +146,8 @@ class PSTN(STN):
                 else:
                     self.add_constraint(i, j, distribution=distribution)
 
-            elif self.nodes[i]['data'].node_type == "delivery":
-                # wait time between finish of one task and start of the next one. Fixed to [0, inf]
+            elif self.nodes[i]['data'].node_type == "finish":
+                # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j)
 
     @staticmethod

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -108,7 +108,7 @@ class STNU(STN):
     def add_intertimepoints_constraints(self, constraints, task):
         """ Adds constraints between the timepoints of a task
         Constraints between:
-        - navigation start and start (contingent)
+        - departure and start (contingent)
         - start and finish (contingent)
         - finish and next task (if any) (requirement)
         Args:
@@ -121,19 +121,19 @@ class STNU(STN):
         """
         for (i, j) in constraints:
             self.logger.debug("Adding constraint: %s ", (i, j))
-            if self.nodes[i]['data'].node_type == "start":
+            if self.nodes[i]['data'].node_type == "departure":
                 lower_bound, upper_bound = self.get_travel_time_bounded_duration(task)
                 if lower_bound == upper_bound:
                     self.add_constraint(i, j, 0, 0)
                 else:
                     self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
-            elif self.nodes[i]['data'].node_type == "pickup":
+            elif self.nodes[i]['data'].node_type == "start":
                 lower_bound, upper_bound = self.get_work_time_bounded_duration(task)
                 self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
-            elif self.nodes[i]['data'].node_type == "delivery":
-                # wait time between finish of one task and start of the next one. Fixed to [0, inf]
+            elif self.nodes[i]['data'].node_type == "finish":
+                # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j, 0)
 
     @staticmethod

--- a/stn/task.py
+++ b/stn/task.py
@@ -44,7 +44,7 @@ class Timepoint(AsDictMixin):
 
 
 class Task(AsDictMixin):
-    def __init__(self, task_id, timepoints, edges, pickup_action_id, delivery_action_id):
+    def __init__(self, task_id, timepoints, edges, start_action_id, finish_action_id):
 
         """ Constructor for the Task object
 
@@ -52,14 +52,14 @@ class Task(AsDictMixin):
             task_id (UUID): An instance of an UUID object
             timepoints (list): list of timepoints (Timepoints)
             Edges (list): list of edges (Edges)
-            pickup_action_id (UUID): Action id of the pickup action
-            delivery_action_id (UUID): Action id of te delivery action
+            start_action_id (UUID): Action id linked to the start timepoint
+            finish_action_id (UUID): Action id linkted to the finish timepoint
         """
         self.task_id = task_id
         self.timepoints = timepoints
         self.edges = edges
-        self.pickup_action_id = pickup_action_id
-        self.delivery_action_id = delivery_action_id
+        self.start_action_id = start_action_id
+        self.finish_action_id = finish_action_id
 
     def __str__(self):
         to_print = ""
@@ -70,8 +70,8 @@ class Task(AsDictMixin):
         to_print += "\n Edges: \n"
         for edge in self.edges:
             to_print += str(edge) + "\t"
-        to_print += "\n Pickup action:" + str(self.pickup_action_id)
-        to_print += "\n Delivery action:" + str(self.delivery_action_id)
+        to_print += "\n Start action:" + str(self.start_action_id)
+        to_print += "\n Finish action:" + str(self.finish_action_id)
         return to_print
 
     def get_timepoint(self, timepoint_name):

--- a/stn/utils/as_dict.py
+++ b/stn/utils/as_dict.py
@@ -44,7 +44,7 @@ class AsDictMixin:
 
     @classmethod
     def _get_value(cls, key, value):
-        if key in ['task_id', 'pickup_action_id', 'delivery_action_id']:
+        if key in ['task_id', 'start_action_id', 'finish_action_id']:
             return from_str(value)
         else:
             return value

--- a/stn/utils/utils.py
+++ b/stn/utils/utils.py
@@ -24,13 +24,13 @@ def load_yaml(file):
 
 def create_task(stn, task_dict):
     task_id = task_dict.get("task_id")
-    r_earliest_pickup = task_dict.get("earliest_pickup")
-    r_latest_pickup = task_dict.get("latest_pickup")
+    r_earliest_start = task_dict.get("earliest_start")
+    r_latest_start = task_dict.get("latest_start")
     travel_time = Edge(**task_dict.get("travel_time"))
     work_time = Edge(**task_dict.get("work_time"))
-    timepoint_constraints = stn.create_timepoint_constraints(r_earliest_pickup, r_latest_pickup, travel_time, work_time)
+    timepoint_constraints = stn.create_timepoint_constraints(r_earliest_start, r_latest_start, travel_time, work_time)
     inter_timepoint_constraints = [travel_time, work_time]
-    pickup_action_id = generate_uuid()
-    delivery_action_id = generate_uuid()
+    start_action_id = generate_uuid()
+    finish_action_id = generate_uuid()
 
-    return Task(task_id, timepoint_constraints, inter_timepoint_constraints, pickup_action_id, delivery_action_id)
+    return Task(task_id, timepoint_constraints, inter_timepoint_constraints, start_action_id, finish_action_id)

--- a/test/data/pstn_two_tasks.json
+++ b/test/data/pstn_two_tasks.json
@@ -195,7 +195,7 @@
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"",
-            "node_type":"start"
+            "node_type":"departure"
          }
       },
       {
@@ -203,7 +203,7 @@
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_9.7_Y_5.6",
-            "node_type":"pickup"
+            "node_type":"start"
          }
       },
       {
@@ -211,7 +211,7 @@
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_5.82_Y_6.57",
-            "node_type":"delivery"
+            "node_type":"finish"
          }
       },
       {
@@ -219,7 +219,7 @@
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"",
-            "node_type":"start"
+            "node_type":"departure"
          }
       },
       {
@@ -227,7 +227,7 @@
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_14.03_Y_9.55",
-            "node_type":"pickup"
+            "node_type":"start"
          }
       },
       {
@@ -235,7 +235,7 @@
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_15.09_Y_5.69",
-            "node_type":"delivery"
+            "node_type":"finish"
          }
       }
    ],

--- a/test/data/stn_two_tasks.json
+++ b/test/data/stn_two_tasks.json
@@ -150,7 +150,7 @@
       {
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
-            "node_type":"start",
+            "node_type":"departure",
             "pose":""
          },
          "id":1
@@ -158,7 +158,7 @@
       {
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
-            "node_type":"pickup",
+            "node_type":"start",
             "pose":"AMK_TDU-TGR-1_X_9.7_Y_5.6"
          },
          "id":2
@@ -166,7 +166,7 @@
       {
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
-            "node_type":"delivery",
+            "node_type":"finish",
             "pose":"AMK_TDU-TGR-1_X_5.82_Y_6.57"
          },
          "id":3
@@ -174,7 +174,7 @@
       {
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
-            "node_type":"start",
+            "node_type":"departure",
             "pose":""
          },
          "id":4
@@ -182,7 +182,7 @@
       {
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
-            "node_type":"pickup",
+            "node_type":"start",
             "pose":"AMK_TDU-TGR-1_X_14.03_Y_9.55"
          },
          "id":5
@@ -190,7 +190,7 @@
       {
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
-            "node_type":"delivery",
+            "node_type":"finish",
             "pose":"AMK_TDU-TGR-1_X_15.09_Y_5.69"
          },
          "id":6

--- a/test/data/stnu_two_tasks.json
+++ b/test/data/stnu_two_tasks.json
@@ -10,7 +10,7 @@
       },
       {
          "data":{
-            "node_type":"start",
+            "node_type":"departure",
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":""
          },
@@ -18,7 +18,7 @@
       },
       {
          "data":{
-            "node_type":"pickup",
+            "node_type":"start",
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_9.7_Y_5.6"
          },
@@ -26,7 +26,7 @@
       },
       {
          "data":{
-            "node_type":"delivery",
+            "node_type":"finish",
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_5.82_Y_6.57"
          },
@@ -34,7 +34,7 @@
       },
       {
          "data":{
-            "node_type":"start",
+            "node_type":"departure",
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":""
          },
@@ -42,7 +42,7 @@
       },
       {
          "data":{
-            "node_type":"pickup",
+            "node_type":"start",
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_14.03_Y_9.55"
          },
@@ -50,7 +50,7 @@
       },
       {
          "data":{
-            "node_type":"delivery",
+            "node_type":"finish",
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_15.09_Y_5.69"
          },

--- a/test/data/tasks.yaml
+++ b/test/data/tasks.yaml
@@ -1,7 +1,7 @@
 0616af00-ec3b-4ecd-ae62-c94a3703594c:
   task_id: 0616af00-ec3b-4ecd-ae62-c94a3703594c
-  earliest_pickup: 10
-  latest_pickup: 20
+  earliest_start: 10
+  latest_start: 20
   travel_time:
     name: "travel_time"
     mean: 5
@@ -12,8 +12,8 @@
     variance: 0.2
 207cc8da-2f0e-4538-802b-b8f3954df38d:
   task_id: 207cc8da-2f0e-4538-802b-b8f3954df38d
-  earliest_pickup: 40
-  latest_pickup: 50
+  earliest_start: 40
+  latest_start: 50
   travel_time:
     name: "travel_time"
     mean: 5
@@ -24,8 +24,8 @@
     variance: 0.2
 0d06fb90-a76d-48b4-b64f-857b7388ab70:
   task_id: 0d06fb90-a76d-48b4-b64f-857b7388ab70
-  earliest_pickup: 70
-  latest_pickup: 80
+  earliest_start: 70
+  latest_start: 80
   travel_time:
     name: "travel_time"
     mean: 5


### PR DESCRIPTION
The previous timepoints names were specific to transportation tasks. The new names are more general and apply to other tasks, e.g. navigation tasks.

Renaming:
`start` -> `departure`
`pickup` -> `start`
`delivery` -> `finish`

`departure`: Time at which the robot starts navigating to the start location.
`start`: Time at which the robot arrives at the start location.
`finish`: Time at which the robot finished the last action.